### PR TITLE
fix(newsletterEdit): fix null id on newsletter edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Feat_
 _Fix_
 
 - [Issue #81](https://github.com/XPEHO/xpeapp_admin/issues/81) Fix calcul of the percent of satisfaction in the qvst detail page
+- [Issue #93](https://github.com/XPEHO/xpeapp_admin/issues/93) Fix null newsletter id on edit attempt
 
 ## 1.0.1
 

--- a/lib/presentation/pages/newsletters/newsletter_add_page.dart
+++ b/lib/presentation/pages/newsletters/newsletter_add_page.dart
@@ -194,6 +194,8 @@ class _NewsletterAddOrEditPageState
                                       NewsletterTypePage.add) {
                                     await sendNewsletter(newsletterEntity);
                                   } else {
+                                    newsletterEntity = newsletterEntity
+                                        .copyWith(id: widget.newsletter?.id);
                                     await updateNewsletter(newsletterEntity);
                                   }
                                 }

--- a/lib/presentation/pages/newsletters/newsletter_detail_page.dart
+++ b/lib/presentation/pages/newsletters/newsletter_detail_page.dart
@@ -32,7 +32,7 @@ class NewsletterDetailPage extends ConsumerWidget {
           }
           NewsletterEntity newsletter = NewsletterEntity.fromJson(
             snapshot.data!.data()!,
-          );
+          ).copyWith(id: id);
           return ScaffoldTemplate(
             appBarTitle: 'Contenu de la newsletter',
             appBarLeading: IconButton(


### PR DESCRIPTION
Closes #93 

The patch retrieves the id of the current newsletter and adds it to the edit request.