### PR TITLE
chore(sonar): migrate sonar scan

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -6,13 +6,19 @@ on:
       - "**"
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Reason for running the workflow"
+        required: true
+        default: "Manually triggered"
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: |
@@ -29,16 +35,10 @@ jobs:
           # Run analysis
           flutter analyze
           # Run tests without user feedback regeneration tests.output and coverage/lcov.info
-          flutter test --machine --coverage > tests.output
-      - name: Sonar-scanner
+          # See https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/test-coverage/dart-test-coverage/#adding-coverage-to-your-build-process
+          flutter test --coverage
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
-          SONAR_SCANNER_VER: sonar-scanner-cli-6.0.0.4432-linux
-          SONAR_SCANNER_PATH: sonar-scanner-6.0.0.4432-linux/bin
-        run: |
-          wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-6.0.0.4432-linux.zip
-          unzip sonar-scanner-cli-6.0.0.4432-linux.zip
-
-          $SONAR_SCANNER_PATH/sonar-scanner -v
-          $SONAR_SCANNER_PATH/sonar-scanner \
-            -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
-            -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -34,6 +34,8 @@ sonar.dart.analyzer.mode=FLUTTER
 # Use existing options to perform dartanalyzer analysis
 sonar.dart.analyzer.options.override=false
 
-sonar.exclusions=test/goldens/**/*, test/failures/**/*, lib/**/*.g.dart
+sonar.exclusions=test/goldens/**/*, test/failures/**/*, lib/**/*.g.dart, lib/**/*.freezed.dart, lib/presentation/**/*.dart, lib/main.dart, lib/routes.dart
 
-sonar.coverage.exclusions=lib/providers.dart
+sonar.coverage.exclusions=lib/providers.dart, lib/**/*.g.dart, lib/**/*.freezed.dart, lib/presentation/**/*.dart, lib/main.dart, lib/routes.dart
+
+sonar.dart.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for SonarQube scanning in the `.github/workflows/sonar.yaml` file. The main changes involve adding a manual trigger for the workflow, updating the checkout action, and simplifying the SonarQube scan job.

Updates to GitHub Actions workflow:

* Added `workflow_dispatch` to allow manual triggering of the workflow with a required input for the reason.
* Updated the `actions/checkout` action from version 3 to version 4.

Simplification of SonarQube scan job:

* Replaced the manual setup of the SonarQube scanner with the `SonarSource/sonarqube-scan-action@v4` action.
* Removed the manual download and setup commands for the SonarQube scanner, and updated the environment variables to use the action's inputs.