### PR TITLE
feat(agenda): add the field agenda on feature flipping

### DIFF
--- a/lib/presentation/pages/feature_flipping/feature_flipping_page.dart
+++ b/lib/presentation/pages/feature_flipping/feature_flipping_page.dart
@@ -89,7 +89,8 @@ class FeatureFlippingPage extends ConsumerWidget {
                           .where((feature) =>
                               feature.idFeature == 'campaign' ||
                               feature.idFeature == 'newsletters' ||
-                              feature.idFeature == 'profile')
+                              feature.idFeature == 'profile' ||
+                              feature.idFeature == 'agenda')
                           .map(
                             (e) => TableRow(
                               children: [


### PR DESCRIPTION
On firestore : 
<img width="481" alt="image" src="https://github.com/user-attachments/assets/359682a1-a008-4d64-8f33-8479002d9297" />

On XpeApp Admin : 

<img width="1222" alt="image" src="https://github.com/user-attachments/assets/17cfc782-483e-4849-b838-081061c93f1d" />
